### PR TITLE
Additional Loadcell Interface

### DIFF
--- a/ESP32/include/LoadCell.h
+++ b/ESP32/include/LoadCell.h
@@ -3,21 +3,28 @@
 #include <stdint.h>
 #include "Main.h"
 
+#define DIFFERENTIAL_0_1 0b00000001
+#define DIFFERENTIAL_2_3 0b00100011
+#define DIFFERENTIAL_4_5 0b01000101
+#define DIFFERENTIAL_6_7 0b01100111
+
 class LoadCell_ADS1256 {
 private:
   float _zeroPoint = 0.0;
   float _varianceEstimate = 0.0;
   float _standardDeviationEstimate = 0.0;
+  float _conversionFactor = 0.0;
+  uint8_t _pedalType=PEDAL_TYPE_BRAKE;
 
 public:
-  LoadCell_ADS1256(uint8_t channel0=0, uint8_t channel1=1);
-  float getReadingKg() const;
-  void setLoadcellRating(uint8_t loadcellRating_u8) const;
+  LoadCell_ADS1256(uint8_t pdType=PEDAL_TYPE_BRAKE, uint8_t differential=DIFFERENTIAL_0_1);
+  float getReadingKg(uint8_t differential=DIFFERENTIAL_0_1) const;
+  void setLoadcellRating(uint8_t loadcellRating_u8);
+  void clearADCBuffer(uint8_t differential=DIFFERENTIAL_0_1);
+public:
+void setZeroPoint(uint8_t differential=DIFFERENTIAL_0_1);
+void estimateVariance(uint8_t differential=DIFFERENTIAL_0_1);
   
-public:
-  void setZeroPoint();
-  void estimateVariance();
-
 public:
   float getVarianceEstimate() const { return _varianceEstimate; }
 };

--- a/ESP32/include/Main.h
+++ b/ESP32/include/Main.h
@@ -22,6 +22,12 @@
 /*                      Other defines       */
 /********************************************************************/
 
+// Define for Loadcell_ADS1256 pedalType
+#define PEDAL_TYPE_CLUTCH 0
+#define PEDAL_TYPE_BRAKE 1
+#define PEDAL_TYPE_GAS 2
+#define PEDAL_TYPE_EXT 3
+
 // target cycle time for pedal update task, to get constant cycle times, required for FIR filtering
 #define DAP_MICROSECONDS_PER_SECOND 1000000
 

--- a/ESP32/platformio.ini
+++ b/ESP32/platformio.ini
@@ -25,7 +25,7 @@ lib_deps_external =
 	gin66/FastAccelStepper @ ^0.31.3
 	dlloydev/QuickPID @ ^3.1.9
 	tomstewart89/BasicLinearAlgebra @ ^3.2
-	https://github.com/ChrGri/ADS1255-ADS1256.git
+	https://github.com/09lab/ADS1256.git
 	#https://github.com/ChrGri/FastNonAccelStepper.git
 	#https://github.com/RobTillaart/FastTrig.git
 


### PR DESCRIPTION
## Additional Loadcell Interface

### feature
- Fix the issue where the system gets stuck when creating two `Loadcell_ADS1256` class objects to support two or more load cells
- To support additional x3 loadcell pedals or handbrake (ex: Fanatec V3 Pedal, Heusinkveld...)

### Appendix
[TI ADS1256](https://www.ti.com/lit/gpn/ADS1255)

### Circuit Configuration
Loadcell to ADS1256 Connection
- Loadcell **VCC** -> 5V
- Loadcell **S+** (Typically Green wire) -> ADC1256 AIN2 or AIN4 or AIN6
- Loadcell **S-** (Typically White wire) -> ADC1256 AIN3 or AIN5 or AIN7
- Loadcell **GND** -> GND