### PR TITLE
DRAFT (develop): Add force-syncing between synced rudder pedals

### DIFF
--- a/Common_Libs/DiyActivePedal_types/src/DiyActivePedal_types.h
+++ b/Common_Libs/DiyActivePedal_types/src/DiyActivePedal_types.h
@@ -144,6 +144,9 @@ typedef struct DapCalculationVariables
   uint32_t currentPedalPosition_u32;
   float currentPedalPositionRatio_fl32;
   float syncPedalPositionRatio_fl32;
+  float currentPedalForce_N_fl32;
+  float syncPedalForce_N_fl32;
+
   volatile bool rudderBrakeStatus_b;
   int32_t stepperPosMinDefault_i32;
   int32_t stepperPosMaxDefault_i32;

--- a/Common_Libs/DiyActivePedal_types/src/PayloadRudderState.h
+++ b/Common_Libs/DiyActivePedal_types/src/PayloadRudderState.h
@@ -4,4 +4,5 @@ typedef struct __attribute__((packed)) PayloadRudderState
 {
   uint16_t pedalPosition_u16;
   float pedalPositionRatio_fl32;
+  float pedalForce_N_fl32;
 } PayloadRudderState_t;

--- a/ESP32/include/StepperMovementStrategy.h
+++ b/ESP32/include/StepperMovementStrategy.h
@@ -554,7 +554,7 @@ float IRAM_ATTR_FLAG MoveByAdmittanceStrategy(
   float loadCellReadingKg_fl32, 
   StepperWithLimits* stepper, 
   ForceCurveInterpolated* forceCurve, 
-  const DapCalculationVariables_t* calc_st, 
+  DapCalculationVariables_t* calc_st, 
   DapConfig_t* config_st, 
   EffectOffsets_t effectOffsets_st, 
   EndstopBehavior_t endstopBehavior_st, 
@@ -598,12 +598,16 @@ float IRAM_ATTR_FLAG MoveByAdmittanceStrategy(
 
   // --- 2. RUDDER CONFIG ---
   float rudderForce_N = 0.0f;
+  float rudderPedalOpposingForce_N = 0.0f;
   if (rudderOffsets_st.isRudderMode) 
   { 
-    float rudderCenter = rudderOffsets_st.centerPosition_01 + rudderOffsets_st.trimOffset_01;
+    //float rudderCenter = rudderOffsets_st.centerPosition_01 + rudderOffsets_st.trimOffset_01;
 
-    float rudderForceRaw_kg = forceCurve->EvalForceCubicSpline(config_st, calc_st, constrain(rudderCenter, 0.0f, 1.0f));
-    rudderForce_N = rudderForceRaw_kg * GRAVITY_N_KG;
+    //float rudderForceRaw_kg = forceCurve->EvalForceCubicSpline(config_st, calc_st, constrain(rudderCenter, 0.0f, 1.0f));
+    //rudderForce_N = rudderForceRaw_kg * GRAVITY_N_KG;
+
+    // add inverse of opposite pedal force
+    rudderPedalOpposingForce_N = -1 * calc_st->syncPedalForce_N_fl32;
 
   }
 
@@ -763,6 +767,12 @@ float IRAM_ATTR_FLAG MoveByAdmittanceStrategy(
 
   // 7. Final total force (Loadcell + Static Effect Weight + Dynamic Effect Force)
   float externalForce_N = (loadCellReadingKg_fl32 * GRAVITY_N_KG) + (effectOffsets_st.forceOffset_kg_fl32 * GRAVITY_N_KG) + effectInjectedForce_N;
+    
+  // save current pedal force for transmission to synced rudder pedal
+  calc_st->currentPedalForce_N_fl32 = externalForce_N;
+   //add opposite pedal force (zero if rudder mode is not active)
+  externalForce_N += rudderPedalOpposingForce_N;
+
 
   // --- 7. DYNAMIC TRAVEL LIMITS ---
   float lowerTravelLimit_01 = 0.0f;
@@ -858,7 +868,7 @@ float IRAM_ATTR_FLAG MoveByAdmittanceStrategy(
   const float VELOCITY_BAND_MPS = 0.030f; // Verbreitert für weicheren Nulldurchgang (verhindert Ruckeln/Schläge bei Richtungswechsel)
   float frictionBlend = constrain(g_vModelVel_mps / VELOCITY_BAND_MPS, -1.0f, 1.0f);
   netForce_N -= (FRICTION_N * frictionBlend);
-
+  
   // =========================================================
   // Integration approaches (Start)
   // =========================================================

--- a/ESP32/src/Main.cpp
+++ b/ESP32/src/Main.cpp
@@ -2236,7 +2236,7 @@ void IRAM_ATTR_FLAG pedalUpdateTask(void *pvParameters) {
             10.0f); // constrain the stiffness to a max value for safety
 
         // rudder variables
-        rudderOffsets_st.isRudderMode = false;
+        rudderOffsets_st.isRudderMode = true;
         rudderOffsets_st.centerPosition_01 = 0.0f;
         rudderOffsets_st.deadzone_01 = 0.0f;
         rudderOffsets_st.trimOffset_01 = 0.0f;
@@ -4063,6 +4063,8 @@ void IRAM_ATTR_FLAG espNowCommunicationTaskTx(void *pvParameters) {
                 dap_calculationVariables_st.currentPedalPositionRatio_fl32;
             g_dapRudderSending_st.payloadRudderState_st.pedalPosition_u16 =
                 dap_calculationVariables_st.currentPedalPosition_u32;
+            g_dapRudderSending_st.payloadRudderState_st.pedalForce_N_fl32 = 
+                dap_calculationVariables_st.currentPedalForce_N_fl32;
             g_dapRudderSending_st.payloadHeader_st.payloadType_u8 =
                 DAP_PAYLOAD_TYPE_ESPNOW_RUDDER_U8;
             g_dapRudderSending_st.payloadHeader_st.pedalTag_u8 =
@@ -4092,6 +4094,9 @@ void IRAM_ATTR_FLAG espNowCommunicationTaskTx(void *pvParameters) {
               dap_calculationVariables_st.syncPedalPositionRatio_fl32 =
                   g_dapRudderReceiving_st.payloadRudderState_st
                       .pedalPositionRatio_fl32;
+              dap_calculationVariables_st.syncPedalForce_N_fl32 =
+                  g_dapRudderReceiving_st.payloadRudderState_st
+                      .pedalForce_N_fl32;
               g_espNowRudderUpdate_b = false;
             }
           }


### PR DESCRIPTION
This PR adds syncing of pedal forces between synced rudder pedals. Any force experienced by one pedal in the pair is inverted and sent to the opposite pedal. IMO, this greatly improves the rudder feel, as it now feels like the rudder pedals are rigidly connected together and cannot be moved independently.

Observations/areas to explore
- High damping/friction is needed to prevent oscillations- this might be because we're transmitting just the external force, not external force + damping?
- The rudder disconnect issue seen in v26.35.01 is still present here - one pedal disconnects a few minutes after entering rudder mode.
